### PR TITLE
disable linting for HTML associated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
         "djlint.profile": "handlebars"
       },
       "[html]": {
-        "djlint.enableLinting": true
+        "djlint.enableLinting": false
       }
     }
   },


### PR DESCRIPTION
Remove "plain" HTML from files DJLint lints. Closes #736
 
