### PR TITLE
Clarify description of "Enable Linting"

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
           "type": "boolean",
           "default": false,
           "scope": "language-overridable",
-          "description": "Lint for common issues."
+          "description": "Override and enable linting for languages not linted by default."
         },
         "djlint.exclude": {
           "type": "array",


### PR DESCRIPTION
This setting description currently says "enable linting" which is what you normally want, but actually it enables linting for all languages.

I struggle a bit to describe this clearly, but this should be less confusing.